### PR TITLE
remove enforcing ibc and channel names during RegisterCoin

### DIFF
--- a/x/erc20/client/cli/tx.go
+++ b/x/erc20/client/cli/tx.go
@@ -20,7 +20,7 @@ import (
 	"github.com/echelonfoundation/echelon/v3/x/erc20/types"
 )
 
-// NewTxCmd returns a root CLI command handler for certain modules/erc20 transaction commands.
+// NewTxCmd returns a root CLI command handler for erc20 transaction commands
 func NewTxCmd() *cobra.Command {
 	txCmd := &cobra.Command{
 		Use:                        types.ModuleName,
@@ -37,11 +37,11 @@ func NewTxCmd() *cobra.Command {
 	return txCmd
 }
 
-// NewConvertCoinCmd returns a CLI command handler for converting cosmos coins
+// NewConvertCoinCmd returns a CLI command handler for converting a Cosmos coin
 func NewConvertCoinCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "convert-coin [coin] [receiver_hex]",
-		Short: "Convert a Cosmos coin to ERC20",
+		Short: "Convert a Cosmos coin to ERC20. When the receiver [optional] is omitted, the ERC20 tokens are transferred to the sender.",
 		Args:  cobra.RangeArgs(1, 2),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			cliCtx, err := client.GetClientTxContext(cmd)
@@ -84,11 +84,11 @@ func NewConvertCoinCmd() *cobra.Command {
 	return cmd
 }
 
-// NewConvertERC20Cmd returns a CLI command handler for converting ERC20s
+// NewConvertERC20Cmd returns a CLI command handler for converting an ERC20
 func NewConvertERC20Cmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "convert-erc20 [contract-address] [amount] [receiver]",
-		Short: "Convert an ERC20 token to Cosmos coin",
+		Short: "Convert an ERC20 token to Cosmos coin.  When the receiver [optional] is omitted, the Cosmos coins are transferred to the sender.",
 		Args:  cobra.RangeArgs(2, 3),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			cliCtx, err := client.GetClientTxContext(cmd)
@@ -149,22 +149,22 @@ The proposal details must be supplied via a JSON file.`,
 Where metadata.json contains (example):
 
 {
-  "description": "staking, gas and governance token of the Echelon testnets"
-  "denom_units": [
+	"description": "The native staking and governance token of the Osmosis chain",
+	"denom_units": [
 		{
-			"denom": "aechelon",
-			"exponent": 0,
-			"aliases": ["atto echelon"]
+				"denom": "ibc/<HASH>",
+				"exponent": 0,
+				"aliases": ["ibcuosmo"]
 		},
 		{
-			"denom": "echelon",
-			"exponent": 18
+				"denom": "OSMO",
+				"exponent": 6
 		}
 	],
-	"base": "aechelon",
-	"display: "echelon",
-	"name": "Echelon",
-	"symbol": "ECH"
+	"base": "ibc/<HASH>",
+	"display": "OSMO",
+	"name": "Osmo",
+	"symbol": "OSMO"
 }`, version.AppName,
 		),
 		RunE: func(cmd *cobra.Command, args []string) error {
@@ -217,7 +217,7 @@ Where metadata.json contains (example):
 
 	cmd.Flags().String(cli.FlagTitle, "", "title of proposal")
 	cmd.Flags().String(cli.FlagDescription, "", "description of proposal")
-	cmd.Flags().String(cli.FlagDeposit, "1aechelon", "deposit of proposal")
+	cmd.Flags().String(cli.FlagDeposit, "aechelon", "deposit of proposal")
 	if err := cmd.MarkFlagRequired(cli.FlagTitle); err != nil {
 		panic(err)
 	}
@@ -237,7 +237,7 @@ func NewRegisterERC20ProposalCmd() *cobra.Command {
 		Args:    cobra.ExactArgs(1),
 		Short:   "Submit a proposal to register an ERC20 token",
 		Long:    "Submit a proposal to register an ERC20 token to the erc20 along with an initial deposit.",
-		Example: fmt.Sprintf("$ %s tx gov submit-proposal register-erc20 <path/to/proposal.json> --from=<key_or_address>", version.AppName),
+		Example: fmt.Sprintf("$ %s tx gov submit-proposal register-erc20 <contract-address> --from=<key_or_address>", version.AppName),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			clientCtx, err := client.GetClientTxContext(cmd)
 			if err != nil {
@@ -283,7 +283,7 @@ func NewRegisterERC20ProposalCmd() *cobra.Command {
 
 	cmd.Flags().String(cli.FlagTitle, "", "title of proposal")
 	cmd.Flags().String(cli.FlagDescription, "", "description of proposal")
-	cmd.Flags().String(cli.FlagDeposit, "1aechelon", "deposit of proposal")
+	cmd.Flags().String(cli.FlagDeposit, "aechelon", "deposit of proposal")
 	if err := cmd.MarkFlagRequired(cli.FlagTitle); err != nil {
 		panic(err)
 	}
@@ -296,14 +296,14 @@ func NewRegisterERC20ProposalCmd() *cobra.Command {
 	return cmd
 }
 
-// NewToggleTokenRelayProposalCmd implements the command to submit a community-pool-spend proposal
-func NewToggleTokenRelayProposalCmd() *cobra.Command {
+// NewToggleTokenConversionProposalCmd implements the command to submit a community-pool-spend proposal
+func NewToggleTokenConversionProposalCmd() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:     "toggle-token-relay [token]",
+		Use:     "toggle-token-conversion [token]",
 		Args:    cobra.ExactArgs(1),
-		Short:   "Submit a toggle token relay proposal",
-		Long:    "Submit a proposal to toggle the relaying of a token pair along with an initial deposit.",
-		Example: fmt.Sprintf("$ %s tx gov submit-proposal toggle-token-relay <denom_or_contract> --from=<key_or_address>", version.AppName),
+		Short:   "Submit a toggle token conversion proposal",
+		Long:    "Submit a proposal to toggle the conversion of a token pair along with an initial deposit.",
+		Example: fmt.Sprintf("$ %s tx gov submit-proposal toggle-token-conversion <denom_or_contract> --from=<key_or_address>", version.AppName),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			clientCtx, err := client.GetClientTxContext(cmd)
 			if err != nil {
@@ -332,7 +332,7 @@ func NewToggleTokenRelayProposalCmd() *cobra.Command {
 
 			from := clientCtx.GetFromAddress()
 			token := args[0]
-			content := types.NewToggleTokenRelayProposal(title, description, token)
+			content := types.NewToggleTokenConversionProposal(title, description, token)
 
 			msg, err := govtypes.NewMsgSubmitProposal(content, deposit, from)
 			if err != nil {
@@ -349,74 +349,7 @@ func NewToggleTokenRelayProposalCmd() *cobra.Command {
 
 	cmd.Flags().String(cli.FlagTitle, "", "title of proposal")
 	cmd.Flags().String(cli.FlagDescription, "", "description of proposal")
-	cmd.Flags().String(cli.FlagDeposit, "1aechelon", "deposit of proposal")
-	if err := cmd.MarkFlagRequired(cli.FlagTitle); err != nil {
-		panic(err)
-	}
-	if err := cmd.MarkFlagRequired(cli.FlagDescription); err != nil {
-		panic(err)
-	}
-	if err := cmd.MarkFlagRequired(cli.FlagDeposit); err != nil {
-		panic(err)
-	}
-	return cmd
-}
-
-// NewUpdateTokenPairERC20ProposalCmd implements the command to submit a community-pool-spend proposal
-func NewUpdateTokenPairERC20ProposalCmd() *cobra.Command {
-	cmd := &cobra.Command{
-		Use:     "update-token-pair-erc20 [erc20_address] [new_erc20_address]",
-		Args:    cobra.ExactArgs(2),
-		Short:   "Submit a update token pair ERC20 proposal",
-		Long:    `Submit a proposal to update the ERC20 address of a token pair along with an initial deposit.`,
-		Example: fmt.Sprintf("$ %s tx gov submit-proposal update-token-pair-erc20 <path/to/proposal.json> --from=<key_or_address>", version.AppName),
-		RunE: func(cmd *cobra.Command, args []string) error {
-			clientCtx, err := client.GetClientTxContext(cmd)
-			if err != nil {
-				return err
-			}
-
-			title, err := cmd.Flags().GetString(cli.FlagTitle)
-			if err != nil {
-				return err
-			}
-
-			description, err := cmd.Flags().GetString(cli.FlagDescription)
-			if err != nil {
-				return err
-			}
-
-			depositStr, err := cmd.Flags().GetString(cli.FlagDeposit)
-			if err != nil {
-				return err
-			}
-
-			deposit, err := sdk.ParseCoinsNormalized(depositStr)
-			if err != nil {
-				return err
-			}
-
-			erc20Addr := args[0]
-			newERC20Addr := args[1]
-
-			from := clientCtx.GetFromAddress()
-			content := types.NewUpdateTokenPairERC20Proposal(title, description, erc20Addr, newERC20Addr)
-			msg, err := govtypes.NewMsgSubmitProposal(content, deposit, from)
-			if err != nil {
-				return err
-			}
-
-			if err := msg.ValidateBasic(); err != nil {
-				return err
-			}
-
-			return tx.GenerateOrBroadcastTxCLI(clientCtx, cmd.Flags(), msg)
-		},
-	}
-
-	cmd.Flags().String(cli.FlagTitle, "", "title of proposal")
-	cmd.Flags().String(cli.FlagDescription, "", "description of proposal")
-	cmd.Flags().String(cli.FlagDeposit, "1aechelon", "deposit of proposal")
+	cmd.Flags().String(cli.FlagDeposit, "aechelon", "deposit of proposal")
 	if err := cmd.MarkFlagRequired(cli.FlagTitle); err != nil {
 		panic(err)
 	}

--- a/x/erc20/types/proposal.go
+++ b/x/erc20/types/proposal.go
@@ -9,35 +9,30 @@ import (
 	banktypes "github.com/cosmos/cosmos-sdk/x/bank/types"
 	govtypes "github.com/cosmos/cosmos-sdk/x/gov/types"
 	ibctransfertypes "github.com/cosmos/ibc-go/v3/modules/apps/transfer/types"
-	"github.com/ethereum/go-ethereum/common"
 	ethermint "github.com/tharsis/ethermint/types"
 )
 
 // constants
 const (
-	ProposalTypeRegisterCoin         string = "RegisterCoin"
-	ProposalTypeRegisterERC20        string = "RegisterERC20"
-	ProposalTypeToggleTokenRelay     string = "ToggleTokenRelay" // #nosec
-	ProposalTypeUpdateTokenPairERC20 string = "UpdateTokenPairERC20"
+	ProposalTypeRegisterCoin          string = "RegisterCoin"
+	ProposalTypeRegisterERC20         string = "RegisterERC20"
+	ProposalTypeToggleTokenConversion string = "ToggleTokenConversion" // #nosec
 )
 
 // Implements Proposal Interface
 var (
 	_ govtypes.Content = &RegisterCoinProposal{}
 	_ govtypes.Content = &RegisterERC20Proposal{}
-	_ govtypes.Content = &ToggleTokenRelayProposal{}
-	_ govtypes.Content = &UpdateTokenPairERC20Proposal{}
+	_ govtypes.Content = &ToggleTokenConversionProposal{}
 )
 
 func init() {
 	govtypes.RegisterProposalType(ProposalTypeRegisterCoin)
 	govtypes.RegisterProposalType(ProposalTypeRegisterERC20)
-	govtypes.RegisterProposalType(ProposalTypeToggleTokenRelay)
-	govtypes.RegisterProposalType(ProposalTypeUpdateTokenPairERC20)
+	govtypes.RegisterProposalType(ProposalTypeToggleTokenConversion)
 	govtypes.RegisterProposalTypeCodec(&RegisterCoinProposal{}, "erc20/RegisterCoinProposal")
 	govtypes.RegisterProposalTypeCodec(&RegisterERC20Proposal{}, "erc20/RegisterERC20Proposal")
-	govtypes.RegisterProposalTypeCodec(&ToggleTokenRelayProposal{}, "erc20/ToggleTokenRelayProposal")
-	govtypes.RegisterProposalTypeCodec(&UpdateTokenPairERC20Proposal{}, "erc20/UpdateTokenPairERC20Proposal")
+	govtypes.RegisterProposalTypeCodec(&ToggleTokenConversionProposal{}, "erc20/ToggleTokenConversionProposal")
 }
 
 // CreateDenomDescription generates a string with the coin description
@@ -77,14 +72,16 @@ func (rtbp *RegisterCoinProposal) ValidateBasic() error {
 		return err
 	}
 
-	if err := validateIBC(rtbp.Metadata); err != nil {
+	if err := validateIBCVoucherMetadata(rtbp.Metadata); err != nil {
 		return err
 	}
 
 	return govtypes.ValidateAbstract(rtbp)
 }
 
-func validateIBC(metadata banktypes.Metadata) error {
+// validateIBCVoucherMetadata checks that the coin metadata fields are consistent
+// with an IBC voucher denomination.
+func validateIBCVoucherMetadata(metadata banktypes.Metadata) error {
 	// Check ibc/ denom
 	denomSplit := strings.SplitN(metadata.Base, "/", 2)
 
@@ -96,14 +93,6 @@ func validateIBC(metadata banktypes.Metadata) error {
 	if len(denomSplit) != 2 || denomSplit[0] != ibctransfertypes.DenomPrefix {
 		// NOTE: should be unaccessible (covered on ValidateIBCDenom)
 		return fmt.Errorf("invalid metadata. %s denomination should be prefixed with the format 'ibc/", metadata.Base)
-	}
-
-	if !strings.Contains(metadata.Name, "channel-") {
-		return fmt.Errorf("invalid metadata (Name) for ibc. %s should include channel", metadata.Name)
-	}
-
-	if !strings.HasPrefix(metadata.Symbol, "ibc") {
-		return fmt.Errorf("invalid metadata (Symbol) for ibc. %s should include \"ibc\" prefix", metadata.Symbol)
 	}
 
 	return nil
@@ -146,9 +135,9 @@ func (rtbp *RegisterERC20Proposal) ValidateBasic() error {
 	return govtypes.ValidateAbstract(rtbp)
 }
 
-// NewToggleTokenRelayProposal returns new instance of ToggleTokenRelayProposal
-func NewToggleTokenRelayProposal(title, description string, token string) govtypes.Content {
-	return &ToggleTokenRelayProposal{
+// NewToggleTokenConversionProposal returns new instance of ToggleTokenConversionProposal
+func NewToggleTokenConversionProposal(title, description string, token string) govtypes.Content {
+	return &ToggleTokenConversionProposal{
 		Title:       title,
 		Description: description,
 		Token:       token,
@@ -156,63 +145,22 @@ func NewToggleTokenRelayProposal(title, description string, token string) govtyp
 }
 
 // ProposalRoute returns router key for this proposal
-func (*ToggleTokenRelayProposal) ProposalRoute() string { return RouterKey }
+func (*ToggleTokenConversionProposal) ProposalRoute() string { return RouterKey }
 
 // ProposalType returns proposal type for this proposal
-func (*ToggleTokenRelayProposal) ProposalType() string {
-	return ProposalTypeToggleTokenRelay
+func (*ToggleTokenConversionProposal) ProposalType() string {
+	return ProposalTypeToggleTokenConversion
 }
 
 // ValidateBasic performs a stateless check of the proposal fields
-func (etrp *ToggleTokenRelayProposal) ValidateBasic() error {
+func (ttcp *ToggleTokenConversionProposal) ValidateBasic() error {
 	// check if the token is a hex address, if not, check if it is a valid SDK
 	// denom
-	if err := ethermint.ValidateAddress(etrp.Token); err != nil {
-		if err := sdk.ValidateDenom(etrp.Token); err != nil {
+	if err := ethermint.ValidateAddress(ttcp.Token); err != nil {
+		if err := sdk.ValidateDenom(ttcp.Token); err != nil {
 			return err
 		}
 	}
 
-	return govtypes.ValidateAbstract(etrp)
-}
-
-// NewUpdateTokenPairERC20Proposal returns new instance of UpdateTokenPairERC20Proposal
-func NewUpdateTokenPairERC20Proposal(title, description, erc20Addr, newERC20Addr string) govtypes.Content {
-	return &UpdateTokenPairERC20Proposal{
-		Title:           title,
-		Description:     description,
-		Erc20Address:    erc20Addr,
-		NewErc20Address: newERC20Addr,
-	}
-}
-
-// ProposalRoute returns router key for this proposal
-func (*UpdateTokenPairERC20Proposal) ProposalRoute() string { return RouterKey }
-
-// ProposalType returns proposal type for this proposal
-func (*UpdateTokenPairERC20Proposal) ProposalType() string {
-	return ProposalTypeUpdateTokenPairERC20
-}
-
-// ValidateBasic performs a stateless check of the proposal fields
-func (p *UpdateTokenPairERC20Proposal) ValidateBasic() error {
-	if err := ethermint.ValidateAddress(p.Erc20Address); err != nil {
-		return sdkerrors.Wrap(err, "ERC20 address")
-	}
-
-	if err := ethermint.ValidateAddress(p.NewErc20Address); err != nil {
-		return sdkerrors.Wrap(err, "new ERC20 address")
-	}
-
-	return govtypes.ValidateAbstract(p)
-}
-
-// GetERC20Address returns the common.Address representation of the ERC20 hex address
-func (p UpdateTokenPairERC20Proposal) GetERC20Address() common.Address {
-	return common.HexToAddress(p.Erc20Address)
-}
-
-// GetNewERC20Address returns the common.Address representation of the new ERC20 hex address
-func (p UpdateTokenPairERC20Proposal) GetNewERC20Address() common.Address {
-	return common.HexToAddress(p.NewErc20Address)
+	return govtypes.ValidateAbstract(ttcp)
 }

--- a/x/erc20/types/proposal_test.go
+++ b/x/erc20/types/proposal_test.go
@@ -10,7 +10,6 @@ import (
 
 	banktypes "github.com/cosmos/cosmos-sdk/x/bank/types"
 	length "github.com/cosmos/cosmos-sdk/x/gov/types"
-	"github.com/ethereum/go-ethereum/common"
 )
 
 type ProposalTestSuite struct {
@@ -26,10 +25,54 @@ func (suite *ProposalTestSuite) TestKeysTypes() {
 	suite.Require().Equal("RegisterCoin", (&RegisterCoinProposal{}).ProposalType())
 	suite.Require().Equal("erc20", (&RegisterERC20Proposal{}).ProposalRoute())
 	suite.Require().Equal("RegisterERC20", (&RegisterERC20Proposal{}).ProposalType())
-	suite.Require().Equal("erc20", (&UpdateTokenPairERC20Proposal{}).ProposalRoute())
-	suite.Require().Equal("UpdateTokenPairERC20", (&UpdateTokenPairERC20Proposal{}).ProposalType())
-	suite.Require().Equal("erc20", (&ToggleTokenRelayProposal{}).ProposalRoute())
-	suite.Require().Equal("ToggleTokenRelay", (&ToggleTokenRelayProposal{}).ProposalType())
+	suite.Require().Equal("erc20", (&ToggleTokenConversionProposal{}).ProposalRoute())
+	suite.Require().Equal("ToggleTokenConversion", (&ToggleTokenConversionProposal{}).ProposalType())
+}
+
+func (suite *ProposalTestSuite) TestCreateDenomDescription() {
+	testCases := []struct {
+		name      string
+		denom     string
+		expString string
+	}{
+		{
+			"with valid address",
+			"0xdac17f958d2ee523a2206206994597c13d831ec7",
+			"Cosmos coin token representation of 0xdac17f958d2ee523a2206206994597c13d831ec7",
+		},
+		{
+			"with empty string",
+			"",
+			"Cosmos coin token representation of ",
+		},
+	}
+	for _, tc := range testCases {
+		desc := CreateDenomDescription(tc.denom)
+		suite.Require().Equal(desc, tc.expString)
+	}
+}
+
+func (suite *ProposalTestSuite) TestCreateDenom() {
+	testCases := []struct {
+		name      string
+		denom     string
+		expString string
+	}{
+		{
+			"with valid address",
+			"0xdac17f958d2ee523a2206206994597c13d831ec7",
+			"erc20/0xdac17f958d2ee523a2206206994597c13d831ec7",
+		},
+		{
+			"with empty string",
+			"",
+			"erc20/",
+		},
+	}
+	for _, tc := range testCases {
+		desc := CreateDenom(tc.denom)
+		suite.Require().Equal(desc, tc.expString)
+	}
 }
 
 func (suite *ProposalTestSuite) TestValidateErc20Denom() {
@@ -45,7 +88,7 @@ func (suite *ProposalTestSuite) TestValidateErc20Denom() {
 		},
 		{
 			"without /",
-			"intrarelayerCoin",
+			"conversionCoin",
 			false,
 		},
 		{
@@ -154,8 +197,8 @@ func (suite *ProposalTestSuite) TestRegisterCoinProposal() {
 	}
 
 	validIBCDenom := "ibc/7F1D3FCF4AE79E1554D670D1AD949A9BA4E4A3C76C63093E17E446A46061A7A2"
-	validIBCSymbol := "ibcATOM-14"
-	validIBCName := "ATOM channel-14"
+	validIBCSymbol := "ATOM"
+	validIBCName := "Atom"
 
 	testCases := []struct {
 		msg         string
@@ -182,8 +225,6 @@ func (suite *ProposalTestSuite) TestRegisterCoinProposal() {
 		// Ibc
 		{msg: "Register token pair - ibc", title: "test", description: "test desc", metadata: createFullMetadata(validIBCDenom, validIBCSymbol, validIBCName), expectPass: true},
 		{msg: "Register token pair - ibc invalid denom", title: "test", description: "test desc", metadata: createFullMetadata("ibc/", validIBCSymbol, validIBCName), expectPass: false},
-		{msg: "Register token pair - ibc invalid symbol", title: "test", description: "test desc", metadata: createFullMetadata(validIBCDenom, "badSymbol", validIBCName), expectPass: false},
-		{msg: "Register token pair - ibc invalid name", title: "test", description: "test desc", metadata: createFullMetadata(validIBCDenom, validIBCSymbol, validIBCDenom), expectPass: false},
 	}
 
 	for i, tc := range testCases {
@@ -198,7 +239,7 @@ func (suite *ProposalTestSuite) TestRegisterCoinProposal() {
 	}
 }
 
-func (suite *ProposalTestSuite) TestToggleTokenRelayProposal() {
+func (suite *ProposalTestSuite) TestToggleTokenConversionProposal() {
 	testCases := []struct {
 		msg         string
 		title       string
@@ -206,27 +247,27 @@ func (suite *ProposalTestSuite) TestToggleTokenRelayProposal() {
 		token       string
 		expectPass  bool
 	}{
-		{msg: "Enable token relay proposal - valid denom", title: "test", description: "test desc", token: "test", expectPass: true},
-		{msg: "Enable token relay proposal - valid address", title: "test", description: "test desc", token: "0x5dCA2483280D9727c80b5518faC4556617fb194F", expectPass: true},
-		{msg: "Enable token relay proposal - invalid address", title: "test", description: "test desc", token: "0x123", expectPass: false},
+		{msg: "Enable token conversion proposal - valid denom", title: "test", description: "test desc", token: "test", expectPass: true},
+		{msg: "Enable token conversion proposal - valid address", title: "test", description: "test desc", token: "0x5dCA2483280D9727c80b5518faC4556617fb194F", expectPass: true},
+		{msg: "Enable token conversion proposal - invalid address", title: "test", description: "test desc", token: "0x123", expectPass: false},
 
 		// Invalid missing params
-		{msg: "Enable token relay proposal - valid missing title", title: "", description: "test desc", token: "test", expectPass: false},
-		{msg: "Enable token relay proposal - valid missing description", title: "test", description: "", token: "test", expectPass: false},
-		{msg: "Enable token relay proposal - invalid missing token", title: "test", description: "test desc", token: "", expectPass: false},
+		{msg: "Enable token conversion proposal - valid missing title", title: "", description: "test desc", token: "test", expectPass: false},
+		{msg: "Enable token conversion proposal - valid missing description", title: "test", description: "", token: "test", expectPass: false},
+		{msg: "Enable token conversion proposal - invalid missing token", title: "test", description: "test desc", token: "", expectPass: false},
 
 		// Invalid regex
-		{msg: "Enable token relay proposal - invalid denom", title: "test", description: "test desc", token: "^test", expectPass: false},
+		{msg: "Enable token conversion proposal - invalid denom", title: "test", description: "test desc", token: "^test", expectPass: false},
 		// Invalid length
-		{msg: "Enable token relay proposal - invalid length (1)", title: "test", description: "test desc", token: "a", expectPass: false},
-		{msg: "Enable token relay proposal - invalid length (128)", title: "test", description: "test desc", token: strings.Repeat("a", 129), expectPass: false},
+		{msg: "Enable token conversion proposal - invalid length (1)", title: "test", description: "test desc", token: "a", expectPass: false},
+		{msg: "Enable token conversion proposal - invalid length (128)", title: "test", description: "test desc", token: strings.Repeat("a", 129), expectPass: false},
 
-		{msg: "Enable token relay proposal - invalid length title (140)", title: strings.Repeat("a", length.MaxTitleLength+1), description: "test desc", token: "test", expectPass: false},
-		{msg: "Enable token relay proposal - invalid length description (5000)", title: "title", description: strings.Repeat("a", length.MaxDescriptionLength+1), token: "test", expectPass: false},
+		{msg: "Enable token conversion proposal - invalid length title (140)", title: strings.Repeat("a", length.MaxTitleLength+1), description: "test desc", token: "test", expectPass: false},
+		{msg: "Enable token conversion proposal - invalid length description (5000)", title: "title", description: strings.Repeat("a", length.MaxDescriptionLength+1), token: "test", expectPass: false},
 	}
 
 	for i, tc := range testCases {
-		tx := NewToggleTokenRelayProposal(tc.title, tc.description, tc.token)
+		tx := NewToggleTokenConversionProposal(tc.title, tc.description, tc.token)
 		err := tx.ValidateBasic()
 
 		if tc.expectPass {
@@ -235,69 +276,4 @@ func (suite *ProposalTestSuite) TestToggleTokenRelayProposal() {
 			suite.Require().Error(err, "invalid test %d passed: %s, %v", i, tc.msg)
 		}
 	}
-}
-
-func (suite *ProposalTestSuite) TestUpdateTokenPairERC20Proposal() {
-	testCases := []struct {
-		msg          string
-		title        string
-		description  string
-		erc20Addr    common.Address
-		newErc20Addr common.Address
-		expectPass   bool
-	}{
-		{msg: "update token pair erc20 - pass", title: "test", description: "test desc", erc20Addr: tests.GenerateAddress(), newErc20Addr: tests.GenerateAddress(), expectPass: true},
-		{msg: "update token pair erc20 - missing title", title: "", description: "test desc", erc20Addr: tests.GenerateAddress(), newErc20Addr: tests.GenerateAddress(), expectPass: false},
-		{msg: "update token pair erc20 - missing description", title: "test", description: "", erc20Addr: tests.GenerateAddress(), newErc20Addr: tests.GenerateAddress(), expectPass: false},
-	}
-
-	for i, tc := range testCases {
-		tx := NewUpdateTokenPairERC20Proposal(tc.title, tc.description, tc.erc20Addr.Hex(), tc.newErc20Addr.Hex())
-		err := tx.ValidateBasic()
-
-		if tc.expectPass {
-			suite.Require().NoError(err, "valid test %d failed: %s, %v", i, tc.msg)
-		} else {
-			suite.Require().Error(err, "invalid test %d passed: %s, %v", i, tc.msg)
-		}
-	}
-}
-
-func (suite *ProposalTestSuite) TestUpdateTokenPairERC20ProposalWithoutConstructor() {
-	testCases := []struct {
-		msg          string
-		title        string
-		description  string
-		erc20Addr    string
-		newErc20Addr string
-		expectPass   bool
-	}{
-		{msg: "update token pair erc20 without constructor - valid", title: "test", description: "desc", erc20Addr: tests.GenerateAddress().String(), newErc20Addr: tests.GenerateAddress().String(), expectPass: true},
-		{msg: "update token pair erc20 without constructor- invalid address 1", title: "test", description: "desc", erc20Addr: tests.GenerateAddress().String(), newErc20Addr: "1x5dCA2483280D9727c80b5518faC4556617fb19F", expectPass: false},
-		{msg: "update token pair erc20 without constructor- invalid address 2", title: "test", description: "desc", erc20Addr: "1x5dCA2483280D9727c80b5518faC4556617fb19F", newErc20Addr: tests.GenerateAddress().String(), expectPass: false},
-	}
-
-	for i, tc := range testCases {
-		tx := UpdateTokenPairERC20Proposal{
-			Title:           tc.title,
-			Description:     tc.description,
-			Erc20Address:    tc.erc20Addr,
-			NewErc20Address: tc.newErc20Addr,
-		}
-		err := tx.ValidateBasic()
-
-		if tc.expectPass {
-			suite.Require().NoError(err, "valid test %d failed: %s, %v", i, tc.msg)
-		} else {
-			suite.Require().Error(err, "invalid test %d passed: %s, %v", i, tc.msg)
-		}
-	}
-}
-
-func (suite *ProposalTestSuite) TestUpdateTokenPairERC20ProposalGetERC20Addresses() {
-	addr := tests.GenerateAddress()
-	addrNew := tests.GenerateAddress()
-	proposal := UpdateTokenPairERC20Proposal{"test", "desc", addr.String(), addrNew.String()}
-	suite.Require().Equal(addr, proposal.GetERC20Address())
-	suite.Require().Equal(addrNew, proposal.GetNewERC20Address())
 }


### PR DESCRIPTION
## Description

Using code via (https://github.com/evmos/evmos/pull/642/commits/66aafdfd4a6d818962dc7538e3687bc2775a5c45). remove enforcing ibc and channel names during RegisterCoin

